### PR TITLE
Add a GH workflow for checking build on PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,14 @@
+# This workflow builds the GitHub Pages site using the same
+# Action that GitHub itself uses when we merge to main.
+# We use it to verify that the site will build correctly
+# before we merge a pull request.
+name: Build GH Pages
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        uses: actions/jekyll-build-pages@v1


### PR DESCRIPTION
I just realized that we don't currently verify that a given PR won't break the GH Pages site!

This just adds a very simple workflow, based on the same actions that GitHub uses to build the GH Pages site itself when we merge to main. It runs it whenever a Pull Request is updated, so that we can be sure that it will build and deploy successfully once merged.